### PR TITLE
explicit check for make command

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -125,7 +125,7 @@ elif [ ${action} = "init" ]; then
        sed -i -e "s/flutter_redux_starter/$package/g" $i
     done
 
-else
+elif [ ${action} = "make" ]; then
 
     package="$2"
     module="$3"


### PR DESCRIPTION
Check that the user actually want to run the 'make' command - so we don't run the command by accident if the user has a typo (prevent lots of cleanup work..)