### PR TITLE
Fix line added mistakenly in app/build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,7 +16,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 27
-    classpath 'com.android.tools.build:gradle:3.2.1'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 


### PR DESCRIPTION
Hi @hillelcoren 

turns out that adding **classpath 'com.android.tools.build:gradle:3.2.1'** in **app/build.gradle**  was a mistake of mine. 
Hope you can merge out it as it is breaking build for android. 
ps. we should definitely cover it with a few tests. I did like you project. I will do my best to contribute 