### PR TITLE
Fixes #11 slash/da-sh issue in starter.sh

### DIFF
--- a/starter.sh
+++ b/starter.sh
@@ -38,7 +38,7 @@ elif [ ${action} = "init" ]; then
 
     echo "Creating files..."
 
-    sed -i -e "s/__API_URL__/$url/g" ./lib/constants.dart
+    sed -i -e "s,__API_URL__,$url,g" ./lib/constants.dart
 
     mv "./android/app/src/main/java/com/hillelcoren" "./android/app/src/main/java/com/$company"
     mv "./android/app/src/main/java/com/$company/flutterreduxstarter" "./android/app/src/main/java/com/$company/$package"


### PR DESCRIPTION
init script no more cries when u add  backslash like server.com/api

https://stackoverflow.com/questions/16778667/how-to-use-sed-to-find-and-replace-url-strings-with-the-character-in-the-tar

Fixes #11 

<img width="306" alt="init" src="https://user-images.githubusercontent.com/2188841/53536190-76cd5c00-3b16-11e9-834b-cd5adfb7f285.png">
